### PR TITLE
fix: Remove unused runtime dependencies used by schema generator

### DIFF
--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -13,13 +13,6 @@
     "build": "node --enable-source-maps --no-warnings=ExperimentalWarning --loader ts-node/esm src/build.ts",
     "prepublishOnly": "lerna run build --scope @mcsb/schemas"
   },
-  "dependencies": {
-    "ajv": "^8.12.0",
-    "dotenv": "^16.3.1",
-    "gen-json-schema": "^0.2.6",
-    "json-diff": "^1.0.6",
-    "json-schema-to-typescript": "^13.1.1"
-  },
   "keywords": [],
   "author": "",
   "license": "MIT",
@@ -29,7 +22,12 @@
   },
   "devDependencies": {
     "@types/json-diff": "^1.0.1",
+    "ajv": "^8.12.0",
+    "dotenv": "^16.3.1",
     "eslint-config-custom": "*",
+    "gen-json-schema": "^0.2.6",
+    "json-diff": "^1.0.6",
+    "json-schema-to-typescript": "^13.1.1",
     "rollup": "^4.1.4",
     "tsconfig": "*"
   },


### PR DESCRIPTION
This fixes #34 